### PR TITLE
修复大小问题导致linux编译失败

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,12 @@
 import { createRouter, createWebHistory, RouterView } from 'vue-router'
 import { h } from 'vue'
 import HomeView from '../views/HomeView.vue'
-import WorkSpace from '../views/workspace/index.vue'
-import HomePageWorkSpace from '../views/workspace/homepage/index.vue'
-import Product from '../views/workspace/product/index.vue'
-import TemplateWorkSpace from '../views/workspace/template/index.vue'
-import FavoritesWorkSpace from '../views/workspace/favorites/index.vue'
-import RecycleWorkSpace from '../views/workspace/recycle/index.vue'
+import WorkSpace from '../views/WorkSpace/index.vue'
+import HomePageWorkSpace from '../views/WorkSpace/homepage/index.vue'
+import Product from '../views/WorkSpace/product/index.vue'
+import TemplateWorkSpace from '../views/WorkSpace/template/index.vue'
+import FavoritesWorkSpace from '../views/WorkSpace/favorites/index.vue'
+import RecycleWorkSpace from '../views/WorkSpace/recycle/index.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),


### PR DESCRIPTION
由于linux环境下区分大小写，会导致路径导入识别失败。

在linux下执行`npm run dev`会报错，修复这个问题。

```shell
➜  press h + enter to show help
10:49:20 PM [vite] Pre-transform error: Failed to resolve import "../views/workspace/index.vue" from "src/router/index.ts". Does the file exist?
Error:   Failed to scan for dependencies from entries:
  /work/jswork/lemon-form/index.html
```